### PR TITLE
Add a "prepareForShow" action to the plugin interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,19 @@ From a successful callback from the camera:
                     alert(message);
                 }
             });
-          
-            
+
 For more information on the above options see the Aviary documentation.
 http://developers.aviary.com/docs
+          
+To allow the plugin the execute any optimizations in preparation for showing the editor:
+
+            cordova.plugins.Aviary.prepareForShow({
+                success: function (result) {
+                    alert("Aviary is prepared to show.");
+                }
+            });
+
+This step is optional and currently only implemented by the iOS plugin.
 
 Known Issues
 ===================

--- a/src/android/com/m1is/aviary/Aviary.java
+++ b/src/android/com/m1is/aviary/Aviary.java
@@ -120,6 +120,9 @@ public class Aviary extends CordovaPlugin {
 				Log.e(LOG_TAG, ex.toString());
 				callbackContext.error("Unknown error occured showing aviary.");
 			}
+		} else if (action.equals("prepareForShow")) {
+			// nothing to do on Android
+			callbackContext.success();
 		}
 
 		return false;

--- a/src/ios/Aviary.h
+++ b/src/ios/Aviary.h
@@ -17,6 +17,7 @@
 @property (nonatomic, retain) NSString* pluginCallbackId;
 @property (nonatomic, retain) NSNumber* quality;
 
+- (void) prepareForShow:(CDVInvokedUrlCommand*)command;
 - (void) show:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/Aviary.m
+++ b/src/ios/Aviary.m
@@ -8,6 +8,13 @@
 @synthesize pluginCallbackId;
 @synthesize quality;
 
+- (void) prepareForShow:(CDVInvokedUrlCommand*) command
+{
+    [AFOpenGLManager beginOpenGLLoad];
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
 - (void) show:(CDVInvokedUrlCommand*) command
 {
     pluginCallbackId = command.callbackId;

--- a/www/Aviary.js
+++ b/www/Aviary.js
@@ -34,6 +34,11 @@ var Aviary = function () {
 };
 
 Aviary.prototype = {
+    prepareForShow: function(options) {
+        options = options || {}
+        cordova.exec(options.success, options.error, "Aviary", "prepareForShow", []);
+    },
+
     show: function (options) {
         var _show = function () {
             cordova.exec(options.success, options.error, "Aviary", "show", [


### PR DESCRIPTION
This pull requests adds a method to allow the plugin to execute any optimizations before showing the Aviary photo editor.  On iOS, `[AFOpenGLManager beginOpenGLLoad ]` is executed, as described [here](http://developers.aviary.com/docs/ios/setup-guide#photo-editor).  On Android, the action is currently a no-op.
